### PR TITLE
Fix: force install the right flake8 version if requested (#37)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,7 @@ runs:
       else
         flake8_version="==${{ inputs.flake8_version }}"
       fi
-      pip show -q flake8 || pip install flake8${flake8_version}
+      pip install flake8${flake8_version}
     shell: bash
   - run: ${{ github.action_path }}/action/entrypoint.sh
     shell: bash


### PR DESCRIPTION
If there was already a flake8 version, this action wouldn't respect
the "flake8_version" argument, stating flake8 was already installed.
This is unexpected, and the requested version should be installed,
even if there is already a flake8 version installed.